### PR TITLE
Add Mavrin interface to extended Lengyel

### DIFF
--- a/extended_lengyel/__init__.py
+++ b/extended_lengyel/__init__.py
@@ -12,6 +12,7 @@ from . import initialize, postprocess
 from . import kallenbach_model
 from . import extended_lengyel_model
 from . import spatial_lengyel_model
+from . import mavrin_data
 
 
 def extend_units_dictionary():
@@ -53,6 +54,7 @@ __all__ = [
     "extended_lengyel_model",
     "initialize",
     "kallenbach_model",
+    "mavrin_data",
     "postprocess",
     "promote_to_coordinate",
     "read_config",

--- a/extended_lengyel/extended_lengyel_model/Lengyel_model_core.py
+++ b/extended_lengyel/extended_lengyel_model/Lengyel_model_core.py
@@ -13,6 +13,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline  # type:ignore[import
 from typing import Self, Callable
 from ..xr_helpers import item, values
 from ..config import setup_impurities
+from ..mavrin_data import MavrinData, SpeciesMavrinData
 
 def _species_as_enum(species: str | AtomicSpecies):
     species = item(species)
@@ -28,7 +29,7 @@ class CzLINT_integrator:
         self,
         impurity_species_list: xr.DataArray,
         impurity_weights_list: xr.DataArray,
-        atomic_data: AtomicData,
+        atomic_data: AtomicData | MavrinData,
         ne_tau: Unitfull = 0.5 * ureg.ms * ureg.n20,
         electron_density: Unitfull = 1.0 * ureg.n20,
         rtol_nearest: float=1e-6,
@@ -81,7 +82,7 @@ class CzLINT_integrator:
 
     @staticmethod
     def build_L_int_integrator(
-        species_atomic_data: xr.Dataset,
+        species_atomic_data: xr.Dataset | SpeciesMavrinData,
         electron_density: Unitfull,
         ne_tau: Unitfull,
         rtol_nearest: float=1e-6,
@@ -91,13 +92,17 @@ class CzLINT_integrator:
         $L_int = \\int_a^b L_z(T_e) sqrt(T_e) dT_e$ where $L_z$ is a cooling curve for an impurity species.
         This is used in the calculation of the radiated power associated with a given impurity.
         """
-        electron_density_ref = magnitude_in_units(electron_density, ureg.m**-3)
-        ne_tau_ref = magnitude_in_units(ne_tau, ureg.m**-3 * ureg.s)
+        if isinstance(species_atomic_data, SpeciesMavrinData):
+            Lz_curve = species_atomic_data.get_Lz_curve(ne_tau)
+        else:
+            electron_density_ref = magnitude_in_units(electron_density, ureg.m**-3)
+            ne_tau_ref = magnitude_in_units(ne_tau, ureg.m**-3 * ureg.s)
 
-        # Select an ne_tau value, requiring that the nearest value is close to the requested value
-        Lz_curve_at_ne_tau = species_atomic_data.equilibrium_Lz.sel(dim_ne_tau=ne_tau_ref, method="nearest", tolerance=rtol_nearest * ne_tau_ref)
-        # Use interpolation to find the value at the given electron density
-        Lz_curve = Lz_curve_at_ne_tau.pint.dequantify().interp(dim_electron_density=electron_density_ref).pint.quantify()
+            # Select an ne_tau value, requiring that the nearest value is close to the requested value
+            Lz_curve_at_ne_tau = species_atomic_data.equilibrium_Lz.sel(
+                dim_ne_tau=ne_tau_ref, method="nearest", tolerance=rtol_nearest * ne_tau_ref)
+            # Use interpolation to find the value at the given electron density
+            Lz_curve = Lz_curve_at_ne_tau.pint.dequantify().interp(dim_electron_density=electron_density_ref).pint.quantify()
 
         electron_temp = Lz_curve.dim_electron_temp
         Lz_sqrt_Te = Lz_curve * np.sqrt(electron_temp)
@@ -138,7 +143,7 @@ class Mean_charge_interpolator:
     def __init__(
         self,
         impurity_species_list: xr.DataArray,
-        atomic_data: AtomicData,
+        atomic_data: AtomicData | MavrinData,
         ne_tau: Unitfull = 0.5 * ureg.ms * ureg.n20,
         electron_density: Unitfull = 1.0 * ureg.n20,
         rtol_nearest: float=1e-6,
@@ -180,19 +185,22 @@ class Mean_charge_interpolator:
 
     @staticmethod
     def build_mean_charge_interpolator(
-        species_atomic_data: xr.Dataset,
+        species_atomic_data: xr.Dataset | SpeciesMavrinData,
         electron_density,
         ne_tau,
         rtol_nearest = 1e-6
     ) -> Callable[[Unitfull], Unitfull]:
         """Build an interpolator to calculate the mean charge."""
-        electron_density_ref = magnitude_in_units(electron_density, ureg.m**-3)
-        reference_ne_tau_ref = magnitude_in_units(ne_tau, ureg.m**-3 * ureg.s)
+        if isinstance(species_atomic_data, SpeciesMavrinData):
+            mean_z_curve = species_atomic_data.get_mean_charge_curve(ne_tau)
+        else:
+            electron_density_ref = magnitude_in_units(electron_density, ureg.m**-3)
+            ne_tau_ref = magnitude_in_units(ne_tau, ureg.m**-3 * ureg.s)
 
-        # Select an ne_tau value, requiring that the nearest value is close to the requested value
-        mean_z_curve_at_ne_tau = species_atomic_data.equilibrium_mean_charge_state.sel(dim_ne_tau=reference_ne_tau_ref, method="nearest", tolerance=rtol_nearest * reference_ne_tau_ref)
-        # Use interpolation to find the value at the given electron density
-        mean_z_curve = mean_z_curve_at_ne_tau.pint.dequantify().interp(dim_electron_density=electron_density_ref).pint.quantify()
+            # Select an ne_tau value, requiring that the nearest value is close to the requested value
+            mean_z_curve_at_ne_tau = species_atomic_data.equilibrium_mean_charge_state.sel(dim_ne_tau=ne_tau_ref, method="nearest", tolerance=rtol_nearest * ne_tau_ref)
+            # Use interpolation to find the value at the given electron density
+            mean_z_curve = mean_z_curve_at_ne_tau.pint.dequantify().interp(dim_electron_density=electron_density_ref).pint.quantify()
 
         electron_temp = mean_z_curve.dim_electron_temp
         interpolator = InterpolatedUnivariateSpline(electron_temp, magnitude(mean_z_curve), ext=3)
@@ -214,7 +222,7 @@ class Mean_charge_interpolator:
     @classmethod
     def from_list(cls,
         impurity_species_list: list[str | AtomicSpecies],
-        atomic_data: AtomicData,
+        atomic_data: AtomicData | MavrinData,
         ne_tau: Unitfull = 0.5 * ureg.ms * ureg.n20,
         electron_density: Unitfull = 1.0 * ureg.n20,
         rtol_nearest: float=1e-6,

--- a/extended_lengyel/mavrin_data.py
+++ b/extended_lengyel/mavrin_data.py
@@ -1,0 +1,62 @@
+"""Interface to atomic data, using the Mavrin polynomials.
+
+This is intended to function as a drop-in replacement for "AtomicData".
+"""
+from cfspopcon.named_options import AtomicSpecies
+from radas.mavrin_reference.read_mavrin_data import read_mavrin_data as _read_mavrin_data, compute_Mavrin_polynomial_fit_single
+from cfspopcon.unit_handling import Unitfull, ureg, wraps_ufunc
+import numpy as np
+import xarray as xr
+from cfspopcon import Algorithm
+
+class SpeciesMavrinData:
+    """An interface to the Mavrin polynomials, for a single atomic species."""
+
+    def __init__(self, species: AtomicSpecies, Lz_coeffs: dict[str, list[float | int]], mean_charge_coeffs: dict[str, list[float | int]]) -> None:
+        """Builds an object to provide atomic data from the Mavrin polynomials, for a single atomic species."""
+        self.species: AtomicSpecies = species
+        self.Lz_coeffs: dict[str, list[float | int]] = Lz_coeffs
+        self.mean_charge_coeffs: dict[str, list[float | int]] = mean_charge_coeffs
+
+    @staticmethod
+    def _return_values_for_curve(coeffs: dict[str, list[float | int]], ne_tau: Unitfull, resolution: int=100) -> xr.DataArray:
+        Tmin = np.min(coeffs["Tmin_eV"])
+        Tmax = np.max(coeffs["Tmax_eV"])
+
+        electron_temp = xr.DataArray(np.logspace(np.log10(Tmin), np.log10(Tmax), num = resolution), dims="dim_electron_temp")
+        electron_temp = np.minimum(np.maximum(electron_temp, Tmin), Tmax)
+
+        curve_function = wraps_ufunc(
+            input_units=dict(Te_eV=ureg.eV, ne_tau_s_per_m3=ureg.m**-3 * ureg.s, coeff=None, warn=None),
+            return_units=dict(result = ureg.W * ureg.m**3),
+            pass_as_kwargs=("coeff", "warn")
+        )(compute_Mavrin_polynomial_fit_single)
+
+        return curve_function(electron_temp * ureg.eV, ne_tau, coeff=coeffs).assign_coords(dim_electron_temp=electron_temp)
+
+    def get_Lz_curve(self, ne_tau: Unitfull, resolution: int=100) -> xr.DataArray:
+        """Returns the Lz curve from the Mavrin polynomial for the given species."""
+        return self._return_values_for_curve(self.Lz_coeffs, ne_tau, resolution)
+
+    def get_mean_charge_curve(self, ne_tau: Unitfull, resolution: int=100) -> xr.DataArray:
+        """Returns the Lz curve from the Mavrin polynomials."""
+        return self._return_values_for_curve(self.mean_charge_coeffs, ne_tau, resolution)
+
+class MavrinData:
+    """An interface to the Mavrin polynomials, for all available atomic species."""
+
+    def __init__(self) -> None:
+        """Builds an object to provide atomic data from the Mavrin polynomials."""
+        mavrin_data = _read_mavrin_data()
+
+        species_available = {key.removesuffix("_Lz").removesuffix("_mean_charge") for key in mavrin_data.keys()}
+
+        self.datasets: dict[AtomicSpecies, SpeciesMavrinData] = dict()
+        for key in species_available:
+            species = AtomicSpecies[key.capitalize()]
+            self.datasets[species] = SpeciesMavrinData(species, mavrin_data[f"{key}_Lz"], mavrin_data[f"{key}_mean_charge"])
+
+@Algorithm.register_algorithm(return_keys=["atomic_data"])
+def read_mavrin_data() -> MavrinData:
+    """Construct a MavrinData interface using the Mavrin polynomials."""
+    return MavrinData()

--- a/tests/test_mavrin_data.py
+++ b/tests/test_mavrin_data.py
@@ -1,0 +1,65 @@
+import pytest
+from cfspopcon.formulas.atomic_data.atomic_data import read_atomic_data, AtomicData
+from extended_lengyel.directories import radas_dir
+from extended_lengyel.mavrin_data import read_mavrin_data, MavrinData, SpeciesMavrinData
+from cfspopcon.named_options import AtomicSpecies
+from extended_lengyel.extended_lengyel_model.Lengyel_model_core import (
+    build_CzLINT_for_seed_impurities,
+    build_mean_charge_for_seed_impurities,
+    set_single_impurity_species
+)
+import numpy as np
+import xarray as xr
+from cfspopcon.unit_handling import magnitude_in_units, ureg
+
+@pytest.fixture()
+def radas_data() -> AtomicData:
+    atomic_data, _ = read_atomic_data(radas_dir=radas_dir)
+    return atomic_data
+
+@pytest.fixture()
+def mavrin_data() -> MavrinData:
+    return read_mavrin_data()
+
+@pytest.fixture()
+def impurity_species() -> AtomicSpecies:
+    return AtomicSpecies["Neon"]
+
+@pytest.fixture()
+def seed_impurity_species(impurity_species):
+    seed_impurity_species, _ = set_single_impurity_species(impurity_species)
+    return seed_impurity_species
+
+@pytest.fixture()
+def seed_impurity_weights(impurity_species):
+    _, seed_impurity_weights = set_single_impurity_species(impurity_species)
+    return seed_impurity_weights
+
+def test_CzLINT_match(radas_data, mavrin_data, seed_impurity_species, seed_impurity_weights):
+
+    CzLINT_radas = build_CzLINT_for_seed_impurities(seed_impurity_species, seed_impurity_weights, radas_data)
+    CzLINT_mavrin = build_CzLINT_for_seed_impurities(seed_impurity_species, seed_impurity_weights, mavrin_data)
+
+    start_temp = 10.0 * ureg.eV
+    stop_temp = 20.0 * ureg.eV
+
+    assert np.isclose(
+        magnitude_in_units(CzLINT_radas(start_temp, stop_temp), ureg.eV**1.5 * ureg.m**3 * ureg.W),
+        magnitude_in_units(CzLINT_mavrin(start_temp, stop_temp), ureg.eV**1.5 * ureg.m**3 * ureg.W),
+        atol = 0.0, # very small values, so use zero absolute tolerance
+        rtol = 1e-1 # only need an approximate match. Data is different, so we expect some differences.
+    )
+
+def test_mean_z_match(radas_data, mavrin_data, seed_impurity_species):
+
+    mean_z_radas = build_mean_charge_for_seed_impurities(seed_impurity_species, radas_data)
+    mean_z_mavrin = build_mean_charge_for_seed_impurities(seed_impurity_species, mavrin_data)
+
+    electron_temp = 10.0 * ureg.eV
+
+    assert np.isclose(
+        magnitude_in_units(mean_z_radas(electron_temp), ureg.dimensionless),
+        magnitude_in_units(mean_z_mavrin(electron_temp), ureg.dimensionless),
+        atol = 0.0,
+        rtol = 1e-1
+    )


### PR DESCRIPTION
Closes #14 

Adds an option to use the Mavrin fits instead of atomic data from OpenADAS, for compatibility with TORAX.