### PR TITLE
Add a forward solve to the extended Lengyel model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The software can be found in the `extended_lengyel` folder. This contains the fo
 * `kallenbach_model`: the model introduced in Kallenbach et al., 2016, "Analytical calculations for impurity seeded  partially detached divertor conditions".
 * `spatial_lengyel_model`: a version of the Lengyel model which does not switch to the temperature-integral form.
 * `extended_lengyel_model`: the main extended Lengyel model discussed in the paper.
+* `iterative_solver`: forward and inverse solves of the same model, sharing a single iteration loop. The *forward* solve is the new capability — given an impurity concentration, iterate to find the target electron temperature.
 
 In addition to this, the software also has shared initialization and post-processing modules, as well as a module for interacting with data from OpenADAS using the [radas](https://github.com/cfs-energy/radas) library. The library is built as an extension of [cfspopcon](https://github.com/cfs-energy/cfspopcon), which allows for straightforward unit-handling and scanning of input parameters.
 
@@ -122,6 +123,62 @@ for species in ds["seed_impurity_species"]:
     cz = (ds["impurity_fraction"] * ds["seed_impurity_weights"]).sel(dim_species=species).item()
     print(f"{species.item()} concentration: {cz:.2}")
 ```
+
+## Running the model forwards
+
+The example above is an *inverse* solve: you give it the target electron temperature you want, and it tells you the impurity concentration needed to reach it. The `iterative_solver` subproject runs the same model in the opposite direction — you give it the impurity concentration, and it iterates to find the resulting target electron temperature.
+
+The forward model computes its own magnetic geometry and parallel heat flux, so the algorithm list is shorter than the inverse one. Note that it also returns a `converged` flag: the fixed-point iteration does not always converge (high impurity concentrations in particular can diverge), and **a non-converged solve returns `NaN` for every physics output**, so always check the flag.
+
+```python
+import cfspopcon
+import extended_lengyel
+import xarray as xr
+from cfspopcon.unit_handling import Quantity, ureg
+
+algorithm = cfspopcon.CompositeAlgorithm.from_list([
+    "set_radas_dir",
+    "read_atomic_data",
+    "build_CzLINT_for_seed_impurities",
+    "build_mean_charge_for_seed_impurities",
+    "run_forward_extended_lengyel_model",
+])
+
+seed_impurity_species, seed_impurity_weights = extended_lengyel.config.setup_impurities(["Nitrogen", "Argon"], [1.0, 0.05])
+
+ds = xr.Dataset(data_vars=dict(
+    seed_impurity_weights                       = seed_impurity_weights,
+    seed_impurity_species                       = seed_impurity_species,
+    # The impurity concentration is now an input, instead of the target electron temperature.
+    impurity_fraction                           = Quantity(3.8, ureg.percent),
+    separatrix_electron_density                 = Quantity(3.3e19, ureg.m**-3),
+    power_crossing_separatrix                   = Quantity(5.5, ureg.MW),
+    fraction_of_P_SOL_to_divertor               = 2/3,
+    divertor_broadening_factor                  = 3.0,
+    plasma_current                              = Quantity(1.0, ureg.MA),
+    magnetic_field_on_axis                      = Quantity(2.5, ureg.T),
+    major_radius                                = Quantity(1.65, ureg.m),
+    minor_radius                                = Quantity(0.5, ureg.m),
+    parallel_connection_length                  = Quantity(20, ureg.m),
+    divertor_parallel_length                    = Quantity(5.0, ureg.m),
+    elongation_psi95                            = 1.6,
+    triangularity_psi95                         = 0.3,
+    target_angle_of_incidence                   = Quantity(3.0, ureg.degree),
+))
+
+algorithm.validate_inputs(ds)
+ds = algorithm.update_dataset(ds)
+
+if ds["converged"].item():
+    print(f"Target electron temperature: {ds['target_electron_temp'].item():.2f}")
+    print(f"Divertor neutral pressure: {ds['neutral_pressure_in_divertor'].item().to(ureg.Pa):.2f}")
+else:
+    print("The forward solve did not converge: its outputs are NaN.")
+```
+
+The subproject also registers `run_inverse_extended_lengyel_model`, which solves in the same direction as the quick-start example above but via the same iteration loop as the forward model (swap the algorithm name and give `target_electron_temp` instead of `impurity_fraction`). It is an independent implementation of the same physics as `run_extended_lengyel_model_with_S_Zeff_and_alphat_correction`, and the two agree closely but not exactly, so pick one and stay with it rather than mixing them.
+
+The forward and inverse models are consistent with each other: feeding the impurity concentration from one into the other recovers the original input, so long as both solves converge.
 
 ## Contributing
 

--- a/extended_lengyel/__init__.py
+++ b/extended_lengyel/__init__.py
@@ -12,6 +12,7 @@ from . import initialize, postprocess
 from . import kallenbach_model
 from . import extended_lengyel_model
 from . import spatial_lengyel_model
+from . import iterative_solver
 from . import mavrin_data
 
 
@@ -53,6 +54,7 @@ __all__ = [
     "adas_data",
     "extended_lengyel_model",
     "initialize",
+    "iterative_solver",
     "kallenbach_model",
     "mavrin_data",
     "postprocess",

--- a/extended_lengyel/extended_units.yaml
+++ b/extended_lengyel/extended_units.yaml
@@ -10,6 +10,7 @@ conduction_prefactor_in_divertor: ""
 conduction_prefactor_in_main_chamber: ""
 conductive_heat_flux_at_target: "W / m**2"
 convective_heat_flux_at_target: "W / m**2"
+converged: null
 CzLINT_for_fixed_impurities: null
 CzLINT_for_seed_impurities: null
 deuterium_adas_data: null
@@ -54,6 +55,7 @@ ion_velocity_epsilon: null
 ion_velocity: "m / s"
 ionization_integral: "1 / meter ** 2 / second"
 ionization_power_loss: "eV / s / meter ** 3"
+iterations: null
 iterations_for_alphat: null
 iterations_for_Lengyel_model: null
 kappa_z: ""

--- a/extended_lengyel/iterative_solver/__init__.py
+++ b/extended_lengyel/iterative_solver/__init__.py
@@ -1,0 +1,26 @@
+"""Iterative solvers for the extended Lengyel model.
+
+Two model variants share the single iteration loop in :mod:`.solver`, and are
+registered in the cfspopcon Algorithm registry under their function names:
+
+* ``run_forward_extended_lengyel_model`` fixes the impurity concentration and
+  solves for the target electron temperature, by relaxed fixed-point iteration.
+* ``run_inverse_extended_lengyel_model`` fixes the target electron temperature
+  and solves for the required impurity concentration directly each iteration.
+
+Both implement the model of Body, Kallenbach and Eich, NF 2025, using the
+reformulated Lengyel solve that combines equations 40 and 43 of that paper.
+:mod:`extended_lengyel.extended_lengyel_model` publishes a second, independent
+implementation of the inverse solve built from the modular algorithms — see the
+note in :mod:`.models`.
+
+A non-converged solve returns NaN for every physics output, so always check the
+returned ``converged`` flag.
+"""
+
+from .models import run_forward_extended_lengyel_model, run_inverse_extended_lengyel_model
+
+__all__ = [
+    "run_forward_extended_lengyel_model",
+    "run_inverse_extended_lengyel_model",
+]

--- a/extended_lengyel/iterative_solver/constants.py
+++ b/extended_lengyel/iterative_solver/constants.py
@@ -1,0 +1,21 @@
+"""Physical constants, unit-conversion factors and fit coefficients shared by the extended Lengyel models."""
+
+mu_0 = 1.2566370621250601e-6  # meter * tesla / ampere
+elementary_charge = 1.602176634e-19  # coulomb
+MA_to_A = 1.0e6  # MA / A
+amu_to_kg = 1.6605390666e-27  # amu / kilogram
+MW_to_W = 1.0e6  # MW / W
+eV_to_J = elementary_charge
+boltzmann_constant = 1.380649e-23  # joule/kelvin
+n20_to_m3 = 1.0e20  # 10^20 / m^3 to 1 / m^3
+
+kappa_e0 = 2390.0  # W / (m * eV**3.5)
+
+# Tolerances for the iterative solvers' convergence test (np.allclose kwargs)
+CONVERGENCE = dict(equal_nan=False, atol=0.0, rtol=1e-6)
+
+# Coefficients for the convection-layer loss functions
+# (equation 33 from Stangeby, 2018, PPCF 60 044022; see physics.temperature_fit_function)
+MOMENTUM_LOSS_FIT = dict(amplitude=0.8858679172531956, width=3.8263045353064467, shape=0.8282347762381935)
+POWER_LOSS_FIT = dict(amplitude=0.8532115334413933, width=5.195481324376164, shape=0.9642427916765323)
+DENSITY_LOSS_FIT = dict(amplitude=0.5587910467003282, width=2.020427078509838, shape=0.9600157520406738)

--- a/extended_lengyel/iterative_solver/models.py
+++ b/extended_lengyel/iterative_solver/models.py
@@ -1,0 +1,144 @@
+"""Public entry points for the forward and inverse extended Lengyel models.
+
+Each wrapper declares the model's units and signature, and delegates to the
+iterative solver in :mod:`.solver`. Both are registered in the cfspopcon
+Algorithm registry under their function names.
+
+Note that ``run_inverse_extended_lengyel_model`` is the second inverse solve in
+this package: :mod:`extended_lengyel.extended_lengyel_model` publishes
+``run_extended_lengyel_model_with_S_Zeff_and_alphat_correction``, which is an
+independent implementation of the same physics built from the modular
+algorithms. The two agree closely (see ``tests/test_forward_lengyel_model.py``)
+but are not identical -- pick one and stay with it rather than mixing them.
+"""
+
+from cfspopcon.algorithm_class import Algorithm
+from cfspopcon.unit_handling import Unitfull, ureg, wraps_ufunc
+
+from ..extended_lengyel_model.Lengyel_model_core import CzLINT_integrator, Mean_charge_interpolator
+
+from .solver import ModelInputs, run_extended_lengyel_solver
+from .units import (
+    FORWARD_RETURN_KEYS,
+    INVERSE_RETURN_KEYS,
+    build_input_units,
+    return_units_for,
+)
+
+
+@Algorithm.register_algorithm(return_keys=list(FORWARD_RETURN_KEYS))
+@wraps_ufunc(
+    input_units=build_input_units("impurity_fraction"),
+    return_units=return_units_for(FORWARD_RETURN_KEYS),
+    output_core_dims=tuple(() for _ in FORWARD_RETURN_KEYS),
+)
+def run_forward_extended_lengyel_model(
+    impurity_fraction: Unitfull,
+    power_crossing_separatrix: Unitfull,
+    separatrix_electron_density: Unitfull,
+    divertor_broadening_factor: Unitfull,
+    CzLINT_for_seed_impurities: CzLINT_integrator,
+    mean_charge_for_seed_impurities: Mean_charge_interpolator,
+    magnetic_field_on_axis: Unitfull,
+    plasma_current: Unitfull,
+    parallel_connection_length: Unitfull,
+    divertor_parallel_length: Unitfull,
+    major_radius: Unitfull,
+    minor_radius: Unitfull,
+    elongation_psi95: Unitfull,
+    triangularity_psi95: Unitfull,
+    target_angle_of_incidence: Unitfull,
+    fraction_of_P_SOL_to_divertor: Unitfull,
+    CzLINT_for_fixed_impurities: CzLINT_integrator | None = None,
+    mean_charge_for_fixed_impurities: Mean_charge_interpolator | None = None,
+    average_ion_mass: Unitfull = 2.0 * ureg.amu,
+    sheath_heat_transmission_factor: Unitfull = 7.5 * ureg.dimensionless,
+    ratio_of_upstream_to_average_poloidal_field: Unitfull = 4.0 / 3.0 * ureg.dimensionless,
+    wall_temperature: Unitfull = 300.0 * ureg.K,
+    SOL_conduction_fraction: Unitfull = 1.0 * ureg.dimensionless,
+    ratio_of_molecular_to_ion_mass: Unitfull = 2.0 * ureg.dimensionless,
+    separatrix_mach_number: float = 0.0,
+    separatrix_ratio_of_ion_to_electron_temp: float = 1.0,
+    separatrix_ratio_of_electron_to_ion_density: float = 1.0,
+    target_ratio_of_ion_to_electron_temp: float = 1.0,
+    target_ratio_of_electron_to_ion_density: float = 1.0,
+    target_mach_number: float = 1.0,
+    toroidal_flux_expansion: float = 1.0,
+    iterations: int = 1000,
+):
+    """Calculate the target electron temperature resulting from a fixed impurity seeding.
+
+    A non-converged solve returns NaN for every physics output: always check the
+    returned ``converged`` flag before using the results.
+    """
+    p = ModelInputs.from_wrapper_args(**locals())
+    r = run_extended_lengyel_solver(p, mode="forward")
+    return (
+        r.target_electron_temp,
+        r.parallel_ion_flux_to_target,
+        r.neutral_pressure_in_divertor,
+        r.alpha_t,
+        r.q_parallel,
+        r.heat_flux_perp_to_target,
+        r.separatrix_z_effective,
+        r.converged,
+    )
+
+
+@Algorithm.register_algorithm(return_keys=list(INVERSE_RETURN_KEYS))
+@wraps_ufunc(
+    input_units=build_input_units("target_electron_temp"),
+    return_units=return_units_for(INVERSE_RETURN_KEYS),
+    output_core_dims=tuple(() for _ in INVERSE_RETURN_KEYS),
+)
+def run_inverse_extended_lengyel_model(
+    target_electron_temp: Unitfull,
+    power_crossing_separatrix: Unitfull,
+    separatrix_electron_density: Unitfull,
+    divertor_broadening_factor: Unitfull,
+    CzLINT_for_seed_impurities: CzLINT_integrator,
+    mean_charge_for_seed_impurities: Mean_charge_interpolator,
+    magnetic_field_on_axis: Unitfull,
+    plasma_current: Unitfull,
+    parallel_connection_length: Unitfull,
+    divertor_parallel_length: Unitfull,
+    major_radius: Unitfull,
+    minor_radius: Unitfull,
+    elongation_psi95: Unitfull,
+    triangularity_psi95: Unitfull,
+    target_angle_of_incidence: Unitfull,
+    fraction_of_P_SOL_to_divertor: Unitfull,
+    CzLINT_for_fixed_impurities: CzLINT_integrator | None = None,
+    mean_charge_for_fixed_impurities: Mean_charge_interpolator | None = None,
+    average_ion_mass: Unitfull = 2.0 * ureg.amu,
+    sheath_heat_transmission_factor: Unitfull = 7.5 * ureg.dimensionless,
+    ratio_of_upstream_to_average_poloidal_field: Unitfull = 4.0 / 3.0 * ureg.dimensionless,
+    wall_temperature: Unitfull = 300.0 * ureg.K,
+    SOL_conduction_fraction: Unitfull = 1.0 * ureg.dimensionless,
+    ratio_of_molecular_to_ion_mass: Unitfull = 2.0 * ureg.dimensionless,
+    separatrix_mach_number: float = 0.0,
+    separatrix_ratio_of_ion_to_electron_temp: float = 1.0,
+    separatrix_ratio_of_electron_to_ion_density: float = 1.0,
+    target_ratio_of_ion_to_electron_temp: float = 1.0,
+    target_ratio_of_electron_to_ion_density: float = 1.0,
+    target_mach_number: float = 1.0,
+    toroidal_flux_expansion: float = 1.0,
+    iterations: int = 1000,
+):
+    """Calculate the impurity concentration required to reach a given target electron temperature.
+
+    A non-converged solve returns NaN for every physics output: always check the
+    returned ``converged`` flag before using the results.
+    """
+    p = ModelInputs.from_wrapper_args(**locals())
+    r = run_extended_lengyel_solver(p, mode="inverse")
+    return (
+        r.impurity_fraction,
+        r.parallel_ion_flux_to_target,
+        r.neutral_pressure_in_divertor,
+        r.alpha_t,
+        r.q_parallel,
+        r.heat_flux_perp_to_target,
+        r.separatrix_z_effective,
+        r.converged,
+    )

--- a/extended_lengyel/iterative_solver/physics.py
+++ b/extended_lengyel/iterative_solver/physics.py
@@ -1,0 +1,313 @@
+"""Pure physics step functions shared by the extended Lengyel model variants.
+
+All functions operate on unitless magnitudes with the same conventions as the
+original model implementations: SI units except electron temperatures in
+electron-volts, electron densities in 10^20 m^-3 (n20) and ion masses in amu
+(unless noted otherwise in the docstring).
+"""
+
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+
+from .constants import (
+    DENSITY_LOSS_FIT,
+    MOMENTUM_LOSS_FIT,
+    POWER_LOSS_FIT,
+    amu_to_kg,
+    boltzmann_constant,
+    elementary_charge,
+    eV_to_J,
+    kappa_e0,
+    mu_0,
+    n20_to_m3,
+)
+
+if TYPE_CHECKING:
+    from .solver import ModelInputs
+
+
+def temperature_fit_function(target_electron_temp: float, amplitude: float, width: float, shape: float) -> float:
+    """A general form for functions in terms of the electron temperature at the target.
+
+    Equation 33 from Stangeby, 2018, PPCF 60 044022
+    """
+    return 1.0 - amplitude * np.power(1.0 - np.exp(-target_electron_temp / width), shape)
+
+
+def calc_alpha_t(
+    separatrix_electron_density: float,
+    separatrix_electron_temp: float,
+    cylindrical_safety_factor: float,
+    major_radius: float,
+    average_ion_mass: float,
+    z_effective: float,
+    mean_ion_charge_state: float,
+    ion_to_electron_temp_ratio: float = 1.0,
+) -> float:
+    """Calculate the turbulence parameter alpha_t.
+
+    Equation 9 from :cite:`Eich_2020`. Compared to this equation, the factor of the
+    ion_to_electron_temp_ratio is added following a discussion with T. Eich.
+
+    For separatrix electron density in per-cubic-metre, separatrix electron temp in electron-volts,
+    major radius in metres, average ion mass in kilograms, and all other inputs dimensionless.
+    """
+    epsilon_0 = 5.5263493580350935e+7  # e^2 eV^-1 m^-1
+    electron_mass = 9.1093837015e-31  # kg
+    eV_to_J = 1.602176634e-19  # Coulomb
+
+    # Calculate the Coulomb logarithm, for electron density in per-cubic-metre and electron temp in electron-volts.
+    # From text on page 6 of :cite:`Verdoolaege_2021`
+    coulomb_log = 30.9 - np.log(separatrix_electron_density**0.5 * separatrix_electron_temp**-1.0)
+    ion_sound_speed = np.sqrt(mean_ion_charge_state * separatrix_electron_temp * eV_to_J / average_ion_mass)
+
+    z_effective_correction = (1.0 - 0.569) * np.exp(-(np.pow(max(z_effective - 1.0, 0.0) / 3.25, 0.85))) + 0.569
+
+    # Calculate the electron-electron collision frequency, using equation B1 from from :cite:`Eich_2020`.
+    nu_ee = (
+        (4.0 / 3.0)
+        * np.sqrt(2.0 * np.pi)
+        * separatrix_electron_density
+        * coulomb_log
+        / ((4.0 * np.pi * epsilon_0) ** 2 * np.sqrt(electron_mass) * separatrix_electron_temp**1.5)
+    ) * np.sqrt(eV_to_J)
+    # Calculate the electron-ion collision frequency, using equation B2 from from :cite:`Eich_2020`.
+    nu_ei = nu_ee * z_effective_correction * z_effective
+
+    alpha_t = (
+        1.02
+        * nu_ei
+        / ion_sound_speed
+        * (1.0 * electron_mass / average_ion_mass)
+        * cylindrical_safety_factor**2
+        * major_radius
+        * (1.0 + ion_to_electron_temp_ratio / mean_ion_charge_state)
+    )
+
+    return alpha_t
+
+
+def relax(new_value: float, prev_value: float, relaxation_factor: float = 0.4) -> float:
+    """Blend a new iterate with the previous one to stabilize fixed-point iteration."""
+    return relaxation_factor * new_value + (1 - relaxation_factor) * prev_value
+
+
+class ConvectionLayerLosses(NamedTuple):
+    """Momentum, power and density loss fractions in the convection layer."""
+
+    momentum: float
+    power: float
+    density: float
+
+
+def calc_convection_layer_losses(target_electron_temp: float) -> ConvectionLayerLosses:
+    """Evaluate the three convection-layer loss functions at the given target electron temperature (eV)."""
+    return ConvectionLayerLosses(
+        momentum=temperature_fit_function(target_electron_temp, **MOMENTUM_LOSS_FIT),
+        power=temperature_fit_function(target_electron_temp, **POWER_LOSS_FIT),
+        density=temperature_fit_function(target_electron_temp, **DENSITY_LOSS_FIT),
+    )
+
+
+def calc_cc_interface_temp(target_electron_temp: float, losses: ConvectionLayerLosses) -> float:
+    """Calculate the electron temperature at the convection-conduction interface (eV)."""
+    return target_electron_temp / ((1.0 - losses.momentum) / (2.0 * losses.density))
+
+
+class Geometry(NamedTuple):
+    """Loop-invariant magnetic field and geometry quantities."""
+
+    separatrix_average_poloidal_field: float
+    cylindrical_safety_factor: float
+    fieldline_pitch_at_omp: float
+    fraction_of_power_entering_flux_tube: float
+    ratio_of_upstream_to_average_lambda_q: float
+    parallel_to_perp_factor: float
+
+
+def calc_geometry(p: "ModelInputs") -> Geometry:
+    """Calculate the loop-invariant magnetic field and geometry quantities from the model inputs."""
+    shaping_factor = np.sqrt(
+        (1.0 + p.elongation_psi95**2 * (1.0 + 2.0 * p.triangularity_psi95**2 - 1.2 * p.triangularity_psi95**3)) / 2.0
+    )
+    poloidal_circumference = 2.0 * np.pi * p.minor_radius * shaping_factor
+
+    upstream_toroidal_field = p.magnetic_field_on_axis * (p.major_radius / (p.major_radius + p.minor_radius))
+    separatrix_average_poloidal_field = mu_0 * p.plasma_current / poloidal_circumference
+    upstream_poloidal_field = p.ratio_of_upstream_to_average_poloidal_field * separatrix_average_poloidal_field
+
+    cylindrical_safety_factor = (
+        p.magnetic_field_on_axis / separatrix_average_poloidal_field * p.minor_radius / p.major_radius * shaping_factor
+    )
+
+    fieldline_pitch_at_omp = np.sqrt(upstream_toroidal_field**2 + upstream_poloidal_field**2) / upstream_poloidal_field
+
+    fraction_of_power_entering_flux_tube = (1.0 - 1.0 / np.e) * p.fraction_of_P_SOL_to_divertor
+
+    ratio_of_upstream_to_average_lambda_q = (
+        p.ratio_of_upstream_to_average_poloidal_field * (p.major_radius + p.minor_radius) / p.major_radius
+    )
+
+    return Geometry(
+        separatrix_average_poloidal_field=separatrix_average_poloidal_field,
+        cylindrical_safety_factor=cylindrical_safety_factor,
+        fieldline_pitch_at_omp=fieldline_pitch_at_omp,
+        fraction_of_power_entering_flux_tube=fraction_of_power_entering_flux_tube,
+        ratio_of_upstream_to_average_lambda_q=ratio_of_upstream_to_average_lambda_q,
+        parallel_to_perp_factor=np.sin(p.target_angle_of_incidence),
+    )
+
+
+def calc_z_effective(
+    impurity_fraction: float, electron_temp_eV: float, p: "ModelInputs", starting_z_effective: float = 1.0
+) -> float:
+    """Calculate the effective charge from the seed and fixed impurity content at the given electron temperature."""
+    seed_mean_z = p.mean_charge_for_seed_impurities.unitless_eval(electron_temp_eV)
+    fixed_mean_z = p.mean_charge_for_fixed_impurities.unitless_eval(electron_temp_eV)
+    seed_c_z = impurity_fraction * p.CzLINT_for_seed_impurities.weights
+    fixed_c_z = p.CzLINT_for_fixed_impurities.weights
+    z_effective = (
+        starting_z_effective
+        + (seed_mean_z * (seed_mean_z - 1.0) * seed_c_z).sum(dim="dim_species")
+        + (fixed_mean_z * (fixed_mean_z - 1.0) * fixed_c_z).sum(dim="dim_species")
+    )
+    return z_effective.values
+
+
+def calc_q_parallel(separatrix_electron_temp: float, alpha_t: float, geo: Geometry, p: "ModelInputs") -> float:
+    """Calculate the parallel heat flux entering the flux tube, consistent with alpha_t and the separatrix electron temperature."""
+    separatrix_average_rho_s_pol = (
+        np.sqrt(separatrix_electron_temp * p.average_ion_mass)
+        / geo.separatrix_average_poloidal_field
+        * np.sqrt(amu_to_kg / elementary_charge)
+    )  # in metres, for Te in eV, mi in amu and B0 in T
+
+    separatrix_average_lambda_Te = 2.1 * (1 + 2.1 * alpha_t**1.7) * separatrix_average_rho_s_pol
+    separatrix_average_lambda_q = 2.0 / 7.0 * separatrix_average_lambda_Te
+
+    lambda_q_outboard_midplane = separatrix_average_lambda_q / geo.ratio_of_upstream_to_average_lambda_q  # in metres
+
+    return (
+        p.power_crossing_separatrix
+        * geo.fraction_of_power_entering_flux_tube
+        / (2.0 * np.pi * (p.major_radius + p.minor_radius) * lambda_q_outboard_midplane)
+        * geo.fieldline_pitch_at_omp
+    )  # in watts per metres-squared
+
+
+def calc_kappa_e(divertor_z_effective: float) -> float:
+    """Calculate the impurity-corrected electron heat conductivity coefficient.
+
+    Uses equation 10 from Brown and Goldston, 2021, NME 27 101002.
+    """
+    kappa_z = 0.672 + 0.076 * np.sqrt(divertor_z_effective) + 0.252 * divertor_z_effective
+    return kappa_e0 / kappa_z
+
+
+def calc_temperature_ladder(
+    electron_temp_at_cc_interface: float, q_parallel: float, kappa_e: float, p: "ModelInputs"
+) -> tuple[float, float]:
+    """Integrate the conduction equation to get the divertor entrance and separatrix electron temperatures (eV)."""
+    divertor_entrance_electron_temp = (
+        electron_temp_at_cc_interface**3.5
+        + 3.5 * p.SOL_conduction_fraction * q_parallel / p.divertor_broadening_factor * p.divertor_parallel_length / kappa_e
+    ) ** (2.0 / 7.0)  # in electron-volts
+
+    separatrix_electron_temp = (
+        divertor_entrance_electron_temp**3.5
+        + 3.5 * p.SOL_conduction_fraction * q_parallel * (p.parallel_connection_length - p.divertor_parallel_length) / kappa_e
+    ) ** (2.0 / 7.0)  # in electron-volts
+
+    return divertor_entrance_electron_temp, separatrix_electron_temp
+
+
+def calc_separatrix_total_pressure(
+    separatrix_electron_density: float, separatrix_electron_temp: float, p: "ModelInputs"
+) -> float:
+    """Calculate the separatrix total pressure in Pascals, for density in n20 and temperature in eV."""
+    return (
+        (1.0 + p.separatrix_mach_number**2)
+        * separatrix_electron_density
+        * separatrix_electron_temp
+        * (1.0 + p.separatrix_ratio_of_ion_to_electron_temp / p.separatrix_ratio_of_electron_to_ion_density)
+    ) * (n20_to_m3 * elementary_charge)  # in Pascals
+
+
+def calc_target_electron_temp_basic(q_parallel: float, separatrix_total_pressure: float, p: "ModelInputs") -> float:
+    """Calculate the basic two-point-model target electron temperature (eV), before loss corrections."""
+    return (
+        (8.0 * p.average_ion_mass / p.sheath_heat_transmission_factor**2) * (q_parallel**2 / separatrix_total_pressure**2)
+    ) * amu_to_kg / elementary_charge
+
+
+def calc_f_other(p: "ModelInputs") -> float:
+    """Calculate the combined target-condition correction factor for the two-point model."""
+    return (
+        ((1.0 + p.target_ratio_of_ion_to_electron_temp / p.target_ratio_of_electron_to_ion_density) / 2.0)
+        * ((1.0 + p.target_mach_number**2) ** 2 / (4.0 * p.target_mach_number**2))
+        * p.toroidal_flux_expansion**-2
+    )
+
+
+class LengyelIntegrals(NamedTuple):
+    """Radiated-power integrals for the seed (Ls) and fixed (Lf) impurities between temperature points."""
+
+    Ls_cc_div: float
+    Ls_div_u: float
+    Lf_cc_div: float
+    Lf_div_u: float
+
+
+def calc_lengyel_integrals(
+    electron_temp_at_cc_interface: float,
+    divertor_entrance_electron_temp: float,
+    separatrix_electron_temp: float,
+    p: "ModelInputs",
+) -> LengyelIntegrals:
+    """Evaluate the Lengyel radiated-power integrals between the cc-interface, divertor entrance and separatrix temperatures."""
+    T_cc, T_div, T_u = electron_temp_at_cc_interface, divertor_entrance_electron_temp, separatrix_electron_temp
+
+    return LengyelIntegrals(
+        # Seed impurities
+        Ls_cc_div=p.CzLINT_for_seed_impurities.unitless_eval(T_cc, T_div) * n20_to_m3**2,
+        Ls_div_u=p.CzLINT_for_seed_impurities.unitless_eval(T_div, T_u) * n20_to_m3**2,
+        # Fixed impurities
+        Lf_cc_div=p.CzLINT_for_fixed_impurities.unitless_eval(T_cc, T_div) * n20_to_m3**2,
+        Lf_div_u=p.CzLINT_for_fixed_impurities.unitless_eval(T_div, T_u) * n20_to_m3**2,
+    )
+
+
+class TargetPostProcessing(NamedTuple):
+    """Target quantities derived from the target electron temperature and parallel heat flux."""
+
+    parallel_ion_flux_to_target: float
+    neutral_pressure_in_divertor: float
+    heat_flux_perp_to_target: float
+
+
+def calc_target_postprocessing(
+    target_electron_temp: float, parallel_heat_flux_at_target: float, geo: Geometry, p: "ModelInputs"
+) -> TargetPostProcessing:
+    """Calculate the ion flux, divertor neutral pressure and perpendicular heat flux at the target."""
+    sound_speed_at_target = np.sqrt(2.0 * target_electron_temp * (eV_to_J / amu_to_kg) / p.average_ion_mass)  # m / s
+
+    electron_density_at_target = parallel_heat_flux_at_target / (
+        p.sheath_heat_transmission_factor * target_electron_temp * eV_to_J * sound_speed_at_target
+    )  # m^-3
+
+    # From equation 57 of Body, Kallenbach and Eich, NF 2025
+    flux_density_to_pascals_factor = np.sqrt(
+        2.0 / (np.pi * p.ratio_of_molecular_to_ion_mass * p.average_ion_mass * p.wall_temperature)
+    ) / np.sqrt(amu_to_kg * boltzmann_constant)  # (m**-2 / s) / Pa
+
+    parallel_ion_flux_to_target = electron_density_at_target * sound_speed_at_target  # m**-2 / s
+    neutral_pressure_in_divertor = parallel_ion_flux_to_target * geo.parallel_to_perp_factor / flux_density_to_pascals_factor  # Pa
+
+    heat_flux_perp_to_target = parallel_heat_flux_at_target * geo.parallel_to_perp_factor  # W/m^2
+
+    return TargetPostProcessing(
+        parallel_ion_flux_to_target=parallel_ion_flux_to_target,
+        neutral_pressure_in_divertor=neutral_pressure_in_divertor,
+        heat_flux_perp_to_target=heat_flux_perp_to_target,
+    )

--- a/extended_lengyel/iterative_solver/solver.py
+++ b/extended_lengyel/iterative_solver/solver.py
@@ -1,0 +1,320 @@
+"""Unified iterative solver for the extended Lengyel model variants.
+
+The public forward model (and the inverse solve used to check it) share a single
+iteration loop, parameterized by:
+
+- ``mode="forward"``: the impurity fraction is given and the target electron
+  temperature is found by relaxed fixed-point iteration.
+- ``mode="inverse"``: the target electron temperature is given and the required
+  impurity fraction is solved for directly each iteration (no relaxation).
+"""
+
+from dataclasses import dataclass, fields, replace
+from typing import Any, Literal
+
+import numpy as np
+
+from ..extended_lengyel_model.Lengyel_model_core import CzLINT_integrator, Mean_charge_interpolator
+
+from .constants import CONVERGENCE, MA_to_A, MW_to_W, amu_to_kg, n20_to_m3
+from .physics import (
+    calc_alpha_t,
+    calc_cc_interface_temp,
+    calc_convection_layer_losses,
+    calc_f_other,
+    calc_geometry,
+    calc_kappa_e,
+    calc_lengyel_integrals,
+    calc_q_parallel,
+    calc_separatrix_total_pressure,
+    calc_target_electron_temp_basic,
+    calc_target_postprocessing,
+    calc_temperature_ladder,
+    calc_z_effective,
+    relax,
+)
+
+
+@dataclass(frozen=True)
+class ModelInputs:
+    """Model inputs as unitless magnitudes (SI except temperatures in eV, densities in n20, ion mass in amu)."""
+
+    power_crossing_separatrix: float  # W
+    divertor_broadening_factor: float
+    CzLINT_for_seed_impurities: CzLINT_integrator
+    mean_charge_for_seed_impurities: Mean_charge_interpolator
+    magnetic_field_on_axis: float  # T
+    plasma_current: float  # A
+    parallel_connection_length: float  # m
+    divertor_parallel_length: float  # m
+    major_radius: float  # m
+    minor_radius: float  # m
+    elongation_psi95: float
+    triangularity_psi95: float
+    target_angle_of_incidence: float  # rad
+    fraction_of_P_SOL_to_divertor: float
+    CzLINT_for_fixed_impurities: CzLINT_integrator
+    mean_charge_for_fixed_impurities: Mean_charge_interpolator
+    average_ion_mass: float  # amu
+    sheath_heat_transmission_factor: float
+    ratio_of_upstream_to_average_poloidal_field: float
+    wall_temperature: float  # K
+    SOL_conduction_fraction: float
+    ratio_of_molecular_to_ion_mass: float
+    separatrix_electron_density: float  # n20
+    separatrix_mach_number: float
+    separatrix_ratio_of_ion_to_electron_temp: float
+    separatrix_ratio_of_electron_to_ion_density: float
+    target_ratio_of_ion_to_electron_temp: float
+    target_ratio_of_electron_to_ion_density: float
+    target_mach_number: float
+    toroidal_flux_expansion: float
+    iterations: int
+    # Mode-specific inputs: the forward model sets impurity_fraction, the inverse
+    # solve sets target_electron_temp.
+    impurity_fraction: float | None = None
+    target_electron_temp: float | None = None  # eV
+
+    @classmethod
+    def from_wrapper_args(cls, **kwargs: Any) -> "ModelInputs":
+        """Build ModelInputs from the public wrapper arguments (magnitudes in the declared input units)."""
+        if kwargs.get("CzLINT_for_fixed_impurities") is None:
+            kwargs["CzLINT_for_fixed_impurities"] = CzLINT_integrator.empty()
+        if kwargs.get("mean_charge_for_fixed_impurities") is None:
+            kwargs["mean_charge_for_fixed_impurities"] = Mean_charge_interpolator.empty()
+
+        # Convert all inputs to SI units, except for electron-volts
+        kwargs["plasma_current"] = kwargs["plasma_current"] * MA_to_A
+        kwargs["target_angle_of_incidence"] = np.deg2rad(kwargs["target_angle_of_incidence"])
+        kwargs["power_crossing_separatrix"] = kwargs["power_crossing_separatrix"] * MW_to_W
+        kwargs["separatrix_electron_density"] = kwargs["separatrix_electron_density"] / n20_to_m3
+
+        return cls(**kwargs)
+
+
+@dataclass
+class SolverResult:
+    """Solver outputs as unitless magnitudes (same conventions as ModelInputs)."""
+
+    impurity_fraction: float
+    target_electron_temp: float  # eV
+    separatrix_electron_density: float  # n20
+    separatrix_electron_temp: float  # eV
+    alpha_t: float
+    q_parallel: float  # W/m^2
+    separatrix_z_effective: float
+    parallel_ion_flux_to_target: float  # m^-2 s^-1
+    neutral_pressure_in_divertor: float  # Pa
+    heat_flux_perp_to_target: float  # W/m^2
+    converged: bool
+
+
+def run_extended_lengyel_solver(p: ModelInputs, mode: Literal["forward", "inverse"]) -> SolverResult:  # noqa: PLR0912, PLR0915
+    """Run the extended Lengyel iteration loop for the requested model variant."""
+    geo = calc_geometry(p)
+
+    # Starting values for the iterative solver
+    if mode == "inverse":
+        # Target temperature is fixed, so the convection-layer losses are loop-invariant
+        losses = calc_convection_layer_losses(p.target_electron_temp)
+        target_electron_temp = p.target_electron_temp
+        electron_temp_at_cc_interface = calc_cc_interface_temp(target_electron_temp, losses)
+        impurity_fraction = np.nan
+        prev_impurity_fraction = np.nan
+    else:
+        impurity_fraction = p.impurity_fraction
+        target_electron_temp = 2.0  # eV
+        electron_temp_at_cc_interface = 2.5  # eV
+        divertor_entrance_electron_temp = 50.0  # eV
+        prev_target_electron_temp = np.nan
+        prev_divertor_entrance_electron_temp = np.nan
+        prev_parallel_heat_flux_at_cc_interface = np.nan
+
+    separatrix_electron_temp = 100.0  # eV
+    alpha_t = 0.0
+    prev_separatrix_electron_temp = np.nan
+    prev_alpha_t = np.nan
+
+    separatrix_electron_density = p.separatrix_electron_density
+
+    for it in range(p.iterations):
+        # Calculate q_parallel consistent with alpha-t and the separatrix electron temperature
+        q_parallel = calc_q_parallel(separatrix_electron_temp, alpha_t, geo, p)
+
+        # Divertor Z_eff for the conductivity correction: the forward model recomputes it from the
+        # known impurity fraction; the inverse solve carries it over from the end of the previous
+        # iteration (starting from 1.0), since the impurity fraction is not yet known.
+        if mode == "forward":
+            divertor_z_effective = calc_z_effective(impurity_fraction, divertor_entrance_electron_temp, p)
+        elif it == 0:
+            divertor_z_effective = 1.0
+        kappa_e = calc_kappa_e(divertor_z_effective)
+
+        divertor_entrance_electron_temp, separatrix_electron_temp = calc_temperature_ladder(
+            electron_temp_at_cc_interface, q_parallel, kappa_e, p
+        )
+
+        qu = q_parallel
+        b = p.divertor_broadening_factor
+
+        if mode == "forward":
+            separatrix_z_effective = calc_z_effective(impurity_fraction, separatrix_electron_temp, p)
+            alpha_t = calc_alpha_t(
+                separatrix_electron_density=separatrix_electron_density * n20_to_m3,
+                separatrix_electron_temp=separatrix_electron_temp,
+                cylindrical_safety_factor=geo.cylindrical_safety_factor,
+                major_radius=p.major_radius,
+                average_ion_mass=p.average_ion_mass * amu_to_kg,
+                z_effective=separatrix_z_effective,
+                mean_ion_charge_state=1.0,
+            )
+
+            # Calculate the power loss due to impurities: all concentrations are known, so the
+            # heat flux at the cc-interface follows from the power balance with the seed
+            # impurities folded into the fixed-concentration radiation term.
+            L = calc_lengyel_integrals(electron_temp_at_cc_interface, divertor_entrance_electron_temp, separatrix_electron_temp, p)
+            Lint_cc_div = impurity_fraction * L.Ls_cc_div + L.Lf_cc_div
+            Lint_div_u = impurity_fraction * L.Ls_div_u + L.Lf_div_u
+
+            k = 2.0 * kappa_e * separatrix_electron_density**2 * separatrix_electron_temp**2
+            qcc_squared = (qu**2 - k * (b**2 * Lint_cc_div + Lint_div_u)) / b**2
+            # More power is radiated than is entering the flux tube: the solve has diverged. Clamp
+            # rather than take the square root of a negative, and let the convergence check below
+            # (or the physicality gate after the loop) report the failure.
+            qcc_squared = max(qcc_squared, 0.0)
+            parallel_heat_flux_at_cc_interface = np.sqrt(qcc_squared)
+
+            separatrix_total_pressure = calc_separatrix_total_pressure(separatrix_electron_density, separatrix_electron_temp, p)
+            target_electron_temp_basic = calc_target_electron_temp_basic(q_parallel, separatrix_total_pressure, p)
+            f_other = calc_f_other(p)
+
+            # Calculate Te_tar consistent with parallel_heat_flux_at_cc_interface
+            losses = calc_convection_layer_losses(target_electron_temp)
+            parallel_heat_flux_at_target = (1.0 - losses.power) * parallel_heat_flux_at_cc_interface
+            SOL_power_loss_fraction = 1.0 - parallel_heat_flux_at_target / q_parallel
+            # On the divergent branch (deep detachment) both the target heat flux and the
+            # momentum-loss complement go to zero, so this is a 0/0 -> nan. The nan correctly flags
+            # non-convergence (allclose then fails), so silence the expected invalid-value warning
+            # rather than alter the result. Convergent cases keep both terms finite.
+            with np.errstate(divide="ignore", invalid="ignore"):
+                f_vol_loss = (1.0 - SOL_power_loss_fraction) ** 2 / (1.0 - losses.momentum) ** 2
+
+            target_electron_temp = target_electron_temp_basic * f_vol_loss * f_other
+
+            electron_temp_at_cc_interface = calc_cc_interface_temp(target_electron_temp, losses)
+
+            current = [
+                alpha_t,
+                target_electron_temp,
+                divertor_entrance_electron_temp,
+                separatrix_electron_temp,
+                parallel_heat_flux_at_cc_interface,
+            ]
+            previous = [
+                prev_alpha_t,
+                prev_target_electron_temp,
+                prev_divertor_entrance_electron_temp,
+                prev_separatrix_electron_temp,
+                prev_parallel_heat_flux_at_cc_interface,
+            ]
+        else:  # inverse
+            separatrix_total_pressure = calc_separatrix_total_pressure(separatrix_electron_density, separatrix_electron_temp, p)
+            target_electron_temp_basic = calc_target_electron_temp_basic(q_parallel, separatrix_total_pressure, p)
+            f_other = calc_f_other(p)
+
+            # Run the two-point-model to calculate the required power loss fraction to achieve
+            # a desired target electron temperature
+            required_power_loss = 1.0 - np.sqrt(
+                target_electron_temp / target_electron_temp_basic * (1.0 - losses.momentum) ** 2 / f_other
+            )
+            parallel_heat_flux_at_target = q_parallel * (1.0 - required_power_loss)  # W/m^2
+            parallel_heat_flux_at_cc_interface = parallel_heat_flux_at_target / (1.0 - losses.power)
+
+            L = calc_lengyel_integrals(electron_temp_at_cc_interface, divertor_entrance_electron_temp, separatrix_electron_temp, p)
+            qcc = parallel_heat_flux_at_cc_interface
+            k = 2.0 * kappa_e * separatrix_electron_density**2 * separatrix_electron_temp**2
+
+            # Reformulated Lengyel solve (combining equations 40 and 43 of Body, Kallenbach and
+            # Eich, NF 2025): the seed-impurity concentration multiplier follows directly from
+            # the power balance, without the intermediate divertor-entrance heat flux q_div.
+            Lambda_seed = b**2 * L.Ls_cc_div + L.Ls_div_u
+            Lambda_fixed = b**2 * L.Lf_cc_div + L.Lf_div_u
+
+            if np.isclose(Lambda_seed, 0.0):
+                impurity_fraction = 0.0
+            else:
+                impurity_fraction = (qu**2 - b**2 * qcc**2) / (k * Lambda_seed) - Lambda_fixed / Lambda_seed
+
+            # Use the divertor entrance temperature to calculate the divertor Zeff, which is used for
+            # calculating the corrected electron heat conductivity in the next iteration
+            divertor_z_effective = calc_z_effective(impurity_fraction, divertor_entrance_electron_temp, p)
+
+            # Use the separatrix electron temperature to calculate Z-eff for alpha-t
+            separatrix_z_effective = calc_z_effective(impurity_fraction, separatrix_electron_temp, p)
+            alpha_t = calc_alpha_t(
+                separatrix_electron_density=separatrix_electron_density * n20_to_m3,
+                separatrix_electron_temp=separatrix_electron_temp,
+                cylindrical_safety_factor=geo.cylindrical_safety_factor,
+                major_radius=p.major_radius,
+                average_ion_mass=p.average_ion_mass * amu_to_kg,
+                z_effective=separatrix_z_effective,
+                mean_ion_charge_state=1.0,
+            )
+
+            current = [alpha_t, impurity_fraction, separatrix_electron_temp]
+            previous = [prev_alpha_t, prev_impurity_fraction, prev_separatrix_electron_temp]
+
+        converged = np.allclose(current, previous, **CONVERGENCE)
+
+        if converged:
+            break
+
+        if mode == "forward":
+            if it > 0:
+                parallel_heat_flux_at_cc_interface = relax(parallel_heat_flux_at_cc_interface, prev_parallel_heat_flux_at_cc_interface)
+                target_electron_temp = relax(target_electron_temp, prev_target_electron_temp)
+                divertor_entrance_electron_temp = relax(divertor_entrance_electron_temp, prev_divertor_entrance_electron_temp)
+                separatrix_electron_temp = relax(separatrix_electron_temp, prev_separatrix_electron_temp)
+                alpha_t = relax(alpha_t, prev_alpha_t)
+            prev_parallel_heat_flux_at_cc_interface = parallel_heat_flux_at_cc_interface
+            prev_target_electron_temp = target_electron_temp
+            prev_divertor_entrance_electron_temp = divertor_entrance_electron_temp
+        else:
+            prev_impurity_fraction = impurity_fraction
+        prev_separatrix_electron_temp = separatrix_electron_temp
+        prev_alpha_t = alpha_t
+
+    post = calc_target_postprocessing(target_electron_temp, parallel_heat_flux_at_target, geo, p)
+
+    # Physicality gate: reject a converged-but-unphysical fixed point, even when the fixed-point
+    # iteration "converges":
+    #   - inverse: a negative impurity fraction (equivalently separatrix Z_eff < 1) means the
+    #     requested target temperature is unreachable with non-negative seeding.
+    #   - forward: a negative target electron temperature is no physical target state.
+    # Forward takes the impurity fraction as a non-negative input, so only the target-temperature
+    # check applies there; the inverse solve is where the impurity fraction is solved for.
+    if converged:
+        if mode == "inverse" and (impurity_fraction < 0.0 or separatrix_z_effective < 1.0):
+            converged = False
+        elif mode == "forward" and target_electron_temp < 0.0:
+            converged = False
+
+    result = SolverResult(
+        impurity_fraction=impurity_fraction,
+        target_electron_temp=target_electron_temp,
+        separatrix_electron_density=separatrix_electron_density,
+        separatrix_electron_temp=separatrix_electron_temp,
+        alpha_t=alpha_t,
+        q_parallel=q_parallel,
+        separatrix_z_effective=separatrix_z_effective,
+        parallel_ion_flux_to_target=post.parallel_ion_flux_to_target,
+        neutral_pressure_in_divertor=post.neutral_pressure_in_divertor,
+        heat_flux_perp_to_target=post.heat_flux_perp_to_target,
+        converged=converged,
+    )
+    if not converged:
+        # A non-converged solve has no valid solution: report NaN for every physics output
+        # (the last-iterate values are iteration-capped and trajectory-sensitive) while keeping
+        # the converged flag so callers can detect and mask the failure.
+        result = replace(result, **{f.name: np.nan for f in fields(result) if f.name != "converged"})
+    return result

--- a/extended_lengyel/iterative_solver/units.py
+++ b/extended_lengyel/iterative_solver/units.py
@@ -1,0 +1,96 @@
+"""Shared unit declarations for the wraps_ufunc decorators of the public model wrappers."""
+
+from cfspopcon.unit_handling import ureg
+
+# Units for the mode-specific leading argument
+DRIVING_UNITS = {
+    "impurity_fraction": ureg.dimensionless,  # forward model
+    "target_electron_temp": ureg.eV,  # inverse solve
+}
+
+# Units for the arguments shared by both models, in signature order
+COMMON_TAIL_INPUT_UNITS = dict(
+    divertor_broadening_factor=ureg.dimensionless,
+    CzLINT_for_seed_impurities=None,
+    mean_charge_for_seed_impurities=None,
+    magnetic_field_on_axis=ureg.T,
+    plasma_current=ureg.MA,
+    parallel_connection_length=ureg.m,
+    divertor_parallel_length=ureg.m,
+    major_radius=ureg.m,
+    minor_radius=ureg.m,
+    elongation_psi95=ureg.dimensionless,
+    triangularity_psi95=ureg.dimensionless,
+    target_angle_of_incidence=ureg.degree,
+    fraction_of_P_SOL_to_divertor=ureg.dimensionless,
+    CzLINT_for_fixed_impurities=None,
+    mean_charge_for_fixed_impurities=None,
+    average_ion_mass=ureg.amu,
+    sheath_heat_transmission_factor=ureg.dimensionless,
+    ratio_of_upstream_to_average_poloidal_field=ureg.dimensionless,
+    wall_temperature=ureg.K,
+    SOL_conduction_fraction=ureg.dimensionless,
+    ratio_of_molecular_to_ion_mass=ureg.dimensionless,
+    separatrix_mach_number=ureg.dimensionless,
+    separatrix_ratio_of_ion_to_electron_temp=ureg.dimensionless,
+    separatrix_ratio_of_electron_to_ion_density=ureg.dimensionless,
+    target_ratio_of_ion_to_electron_temp=ureg.dimensionless,
+    target_ratio_of_electron_to_ion_density=ureg.dimensionless,
+    target_mach_number=ureg.dimensionless,
+    toroidal_flux_expansion=ureg.dimensionless,
+    iterations=None,
+)
+
+
+def build_input_units(driving_key: str) -> dict:
+    """Build the full wraps_ufunc input_units dict for one model variant.
+
+    Args:
+        driving_key: "impurity_fraction" (forward) or "target_electron_temp" (inverse).
+    """
+    return {
+        driving_key: DRIVING_UNITS[driving_key],
+        "power_crossing_separatrix": ureg.MW,
+        "separatrix_electron_density": ureg.m**-3,
+        **COMMON_TAIL_INPUT_UNITS,
+    }
+
+
+# Canonical units for every possible return key; each model selects its keys below.
+RETURN_UNITS = {
+    "impurity_fraction": ureg.dimensionless,
+    "target_electron_temp": ureg.eV,
+    "parallel_ion_flux_to_target": ureg.m**-2 * ureg.s**-1,
+    "neutral_pressure_in_divertor": ureg.Pa,
+    "alpha_t": ureg.dimensionless,
+    "q_parallel": ureg.W / ureg.m**2,
+    "heat_flux_perp_to_target": ureg.W / ureg.m**2,
+    "separatrix_z_effective": ureg.dimensionless,
+    "converged": None,
+}
+
+FORWARD_RETURN_KEYS = (
+    "target_electron_temp",
+    "parallel_ion_flux_to_target",
+    "neutral_pressure_in_divertor",
+    "alpha_t",
+    "q_parallel",
+    "heat_flux_perp_to_target",
+    "separatrix_z_effective",
+    "converged",
+)
+INVERSE_RETURN_KEYS = (
+    "impurity_fraction",
+    "parallel_ion_flux_to_target",
+    "neutral_pressure_in_divertor",
+    "alpha_t",
+    "q_parallel",
+    "heat_flux_perp_to_target",
+    "separatrix_z_effective",
+    "converged",
+)
+
+
+def return_units_for(keys: tuple[str, ...]) -> dict:
+    """Select the wraps_ufunc return_units dict for the given return keys."""
+    return {key: RETURN_UNITS[key] for key in keys}

--- a/tests/test_forward_lengyel_model.py
+++ b/tests/test_forward_lengyel_model.py
@@ -1,0 +1,334 @@
+"""Tests for the iterative forward extended Lengyel model.
+
+The reference values below are a regression baseline: they were produced by the
+original (pre-refactor) implementations of these models and are pinned in the
+golden file of the extended-lengyel-validation project, which remains the
+authoritative regression suite. They use the Mavrin polynomial atomic data, so
+this test does not depend on a radas dataset being built.
+"""
+
+import numpy as np
+import pytest
+from cfspopcon.named_options import AtomicSpecies
+from cfspopcon.unit_handling import magnitude_in_units, ureg
+
+from extended_lengyel.extended_lengyel_model.Lengyel_model_core import CzLINT_integrator, Mean_charge_interpolator
+from extended_lengyel.iterative_solver import run_forward_extended_lengyel_model, run_inverse_extended_lengyel_model
+from extended_lengyel.mavrin_data import read_mavrin_data
+
+
+@pytest.fixture(autouse=True)
+def raise_on_float_errors():
+    """Make silent over/underflow in the solver fail these tests (scoped, so it does not leak)."""
+    with np.errstate(over="raise", under="raise"):
+        yield
+
+
+# Plasma parameters shared by every reference case.
+BASE_KWARGS = dict(
+    power_crossing_separatrix=5.5 * ureg.MW,
+    divertor_broadening_factor=3.0,
+    magnetic_field_on_axis=2.5 * ureg.T,
+    plasma_current=1.0 * ureg.MA,
+    parallel_connection_length=20.0 * ureg.m,
+    divertor_parallel_length=5.0 * ureg.m,
+    major_radius=1.65 * ureg.m,
+    minor_radius=0.5 * ureg.m,
+    elongation_psi95=1.6,
+    triangularity_psi95=0.3,
+    target_angle_of_incidence=3.0,
+    fraction_of_P_SOL_to_divertor=2.0 / 3.0,
+    sheath_heat_transmission_factor=8.0,
+    iterations=100,
+)
+
+# Units of the per-case inputs and of every model output.
+OVERRIDE_UNITS = dict(
+    impurity_fraction=ureg.dimensionless,
+    target_electron_temp=ureg.eV,
+    separatrix_electron_density=ureg.n19,
+    power_crossing_separatrix=ureg.MW,
+)
+OUTPUT_UNITS = dict(
+    target_electron_temp=ureg.eV,
+    impurity_fraction=ureg.dimensionless,
+    parallel_ion_flux_to_target=ureg.m**-2 / ureg.s,
+    neutral_pressure_in_divertor=ureg.Pa,
+    alpha_t=ureg.dimensionless,
+    q_parallel=ureg.W / ureg.m**2,
+    heat_flux_perp_to_target=ureg.W / ureg.m**2,
+    separatrix_z_effective=ureg.dimensionless,
+)
+
+FORWARD_RETURN_KEYS = (
+    "target_electron_temp",
+    "parallel_ion_flux_to_target",
+    "neutral_pressure_in_divertor",
+    "alpha_t",
+    "q_parallel",
+    "heat_flux_perp_to_target",
+    "separatrix_z_effective",
+)
+
+# (inputs, expected outputs) for the converged reference cases.
+FORWARD_REFERENCE_CASES = [
+    (
+        dict(impurity_fraction=0.01, separatrix_electron_density=2.5),
+        dict(
+            target_electron_temp=65.49112461678739,
+            parallel_ion_flux_to_target=1.4681064591614932e24,
+            neutral_pressure_in_divertor=0.5050966227756978,
+            alpha_t=0.17692094272990122,
+            q_parallel=436134412.5994577,
+            heat_flux_perp_to_target=6449715.261109519,
+            separatrix_z_effective=1.2406625829525029,
+        ),
+    ),
+    (
+        dict(impurity_fraction=0.01, separatrix_electron_density=3.3),
+        dict(
+            target_electron_temp=35.94328406827099,
+            parallel_ion_flux_to_target=2.4609526880213976e24,
+            neutral_pressure_in_divertor=0.8466817128781872,
+            alpha_t=0.260053003958726,
+            q_parallel=411740890.595647,
+            heat_flux_perp_to_target=5933645.0604971405,
+            separatrix_z_effective=1.241869557819673,
+        ),
+    ),
+    (
+        dict(impurity_fraction=0.038, separatrix_electron_density=2.5),
+        dict(
+            target_electron_temp=53.977817609083225,
+            parallel_ion_flux_to_target=1.6112141020396254e24,
+            neutral_pressure_in_divertor=0.5543322804897981,
+            alpha_t=0.24624239649550964,
+            q_parallel=406424307.37085736,
+            heat_flux_perp_to_target=5834036.209256478,
+            separatrix_z_effective=1.8590885204144865,
+        ),
+    ),
+    (
+        dict(impurity_fraction=0.038, separatrix_electron_density=3.3),
+        dict(
+            target_electron_temp=2.4566047419660366,
+            parallel_ion_flux_to_target=5.0708001889293e24,
+            neutral_pressure_in_divertor=1.74459013800771,
+            alpha_t=0.3598835042569608,
+            q_parallel=364587978.86462486,
+            heat_flux_perp_to_target=835626.7383516281,
+            separatrix_z_effective=1.8640696385197995,
+        ),
+    ),
+    (
+        dict(impurity_fraction=0.06, separatrix_electron_density=2.5),
+        dict(
+            target_electron_temp=43.08974428274713,
+            parallel_ion_flux_to_target=1.800246557385063e24,
+            neutral_pressure_in_divertor=0.6193682008715609,
+            alpha_t=0.2962506740650417,
+            q_parallel=383753753.24930555,
+            heat_flux_perp_to_target=5203630.496488394,
+            separatrix_z_effective=2.344755836032303,
+        ),
+    ),
+    (
+        dict(impurity_fraction=0.038, separatrix_electron_density=3.3, power_crossing_separatrix=8.0),
+        dict(
+            target_electron_temp=45.91719174198923,
+            parallel_ion_flux_to_target=2.4741026848392794e24,
+            neutral_pressure_in_divertor=0.8512059208746677,
+            alpha_t=0.28329227383734557,
+            q_parallel=546823857.8257205,
+            heat_flux_perp_to_target=7620677.517582321,
+            separatrix_z_effective=1.879207470757456,
+        ),
+    ),
+]
+
+# Inputs for which the fixed-point iteration is known not to converge.
+FORWARD_NON_CONVERGENT_CASES = [
+    dict(impurity_fraction=0.06, separatrix_electron_density=3.3),
+    dict(impurity_fraction=0.1, separatrix_electron_density=2.5),
+    dict(impurity_fraction=0.1, separatrix_electron_density=3.3),
+    dict(impurity_fraction=0.038, separatrix_electron_density=3.3, power_crossing_separatrix=4.0),
+]
+
+
+@pytest.fixture(scope="module")
+def model_kwargs() -> dict:
+    """Base plasma parameters plus the Nitrogen + Argon seed and Helium fixed impurity interpolators."""
+    atomic_data = read_mavrin_data()
+    seed_species = [AtomicSpecies.Nitrogen, AtomicSpecies.Argon]
+    seed_weights = [1.0, 0.05]
+    fixed_species = [AtomicSpecies.Helium]
+    fixed_weights = [1.0e-2]
+
+    return dict(
+        BASE_KWARGS,
+        CzLINT_for_seed_impurities=CzLINT_integrator.from_list(seed_species, seed_weights, atomic_data),
+        mean_charge_for_seed_impurities=Mean_charge_interpolator.from_list(seed_species, atomic_data),
+        CzLINT_for_fixed_impurities=CzLINT_integrator.from_list(fixed_species, fixed_weights, atomic_data),
+        mean_charge_for_fixed_impurities=Mean_charge_interpolator.from_list(fixed_species, atomic_data),
+    )
+
+
+def apply_overrides(model_kwargs: dict, overrides: dict) -> dict:
+    """Return model_kwargs with the per-case overrides applied, converting magnitudes to quantities."""
+    return dict(model_kwargs, **{key: value * OVERRIDE_UNITS[key] for key, value in overrides.items()})
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"), FORWARD_REFERENCE_CASES, ids=[str(case[0]) for case in FORWARD_REFERENCE_CASES]
+)
+def test_forward_model_against_reference_values(model_kwargs, overrides, expected):
+    """The forward model reproduces the reference values of the original implementation."""
+    *outputs, converged = run_forward_extended_lengyel_model(**apply_overrides(model_kwargs, overrides))
+    assert converged
+
+    for key, output in zip(FORWARD_RETURN_KEYS, outputs, strict=True):
+        assert np.isclose(magnitude_in_units(output, OUTPUT_UNITS[key]), expected[key], rtol=1e-5, atol=0.0), key
+
+
+@pytest.mark.parametrize("overrides", FORWARD_NON_CONVERGENT_CASES, ids=[str(case) for case in FORWARD_NON_CONVERGENT_CASES])
+def test_forward_model_reports_non_convergence(model_kwargs, overrides):
+    """A non-converged solve reports converged=False and returns NaN for every physics output."""
+    *outputs, converged = run_forward_extended_lengyel_model(**apply_overrides(model_kwargs, overrides))
+    assert not converged
+
+    for key, output in zip(FORWARD_RETURN_KEYS, outputs, strict=True):
+        assert np.isnan(magnitude_in_units(output, OUTPUT_UNITS[key])), key
+
+
+def test_forward_model_inverts_the_inverse_model(model_kwargs):
+    """Feeding the inverse model's impurity fraction back into the forward model recovers its inputs."""
+    target_electron_temp = 2.34 * ureg.eV
+
+    impurity_fraction, *inverse_outputs, inverse_converged = run_inverse_extended_lengyel_model(
+        target_electron_temp=target_electron_temp, separatrix_electron_density=3.3 * ureg.n19, **model_kwargs
+    )
+    assert inverse_converged
+
+    target_electron_temp_out, *forward_outputs, forward_converged = run_forward_extended_lengyel_model(
+        impurity_fraction=impurity_fraction, separatrix_electron_density=3.3 * ureg.n19, **model_kwargs
+    )
+    assert forward_converged
+
+    assert np.isclose(
+        magnitude_in_units(target_electron_temp_out, ureg.eV), magnitude_in_units(target_electron_temp, ureg.eV), rtol=1e-3
+    )
+    # Both solves describe the same plasma state, so every derived output must agree.
+    for key, inverse_output, forward_output in zip(FORWARD_RETURN_KEYS[1:], inverse_outputs, forward_outputs, strict=True):
+        assert np.isclose(
+            magnitude_in_units(inverse_output, OUTPUT_UNITS[key]),
+            magnitude_in_units(forward_output, OUTPUT_UNITS[key]),
+            rtol=1e-3,
+        ), key
+
+
+def test_forward_model_agrees_with_the_published_inverse_model():
+    """The forward model inverts run_extended_lengyel_model_with_S_Zeff_and_alphat_correction.
+
+    That model is an independent implementation of the same physics (Body, Kallenbach and Eich,
+    NF 2025), built from the modular algorithms rather than the iteration loop of this subpackage,
+    so agreement between the two is a cross-check of the port and not a self-consistency check.
+    """
+    import cfspopcon
+    import xarray as xr
+
+    from extended_lengyel.config import setup_impurities
+
+    seed_impurity_species, seed_impurity_weights = setup_impurities(["Nitrogen", "Argon"], [1.0, 0.05])
+    target_electron_temp = 2.0 * ureg.eV
+
+    shared_inputs = dict(
+        seed_impurity_species=seed_impurity_species,
+        seed_impurity_weights=seed_impurity_weights,
+        sheath_heat_transmission_factor=8.0,
+        ratio_of_upstream_to_average_poloidal_field=4.0 / 3.0,
+        separatrix_electron_density=3.3e19 * ureg.m**-3,
+        power_crossing_separatrix=5.5 * ureg.MW,
+        fraction_of_P_SOL_to_divertor=2.0 / 3.0,
+        divertor_broadening_factor=3.0,
+        plasma_current=1.0 * ureg.MA,
+        magnetic_field_on_axis=2.5 * ureg.T,
+        major_radius=1.65 * ureg.m,
+        minor_radius=0.5 * ureg.m,
+        parallel_connection_length=20.0 * ureg.m,
+        divertor_parallel_length=5.0 * ureg.m,
+        elongation_psi95=1.6,
+        triangularity_psi95=0.3,
+        target_angle_of_incidence=3.0 * ureg.degree,
+    )
+
+    inverse_algorithm = cfspopcon.CompositeAlgorithm.from_list(
+        [
+            "calc_magnetic_field_and_safety_factor",
+            "calc_fieldline_pitch_at_omp",
+            "set_radas_dir",
+            "read_atomic_data",
+            "build_CzLINT_for_seed_impurities",
+            "calc_kappa_e0",
+            "build_mean_charge_for_seed_impurities",
+            "calc_momentum_loss_from_cc_fit",
+            "calc_power_loss_from_cc_fit",
+            "calc_electron_temp_from_cc_fit",
+            "run_extended_lengyel_model_with_S_Zeff_and_alphat_correction",
+        ]
+    )
+    inverse = inverse_algorithm.update_dataset(
+        xr.Dataset(
+            data_vars=dict(ion_mass=2.0 * ureg.amu, target_electron_temp=target_electron_temp, **shared_inputs)
+        )
+    )
+
+    forward_algorithm = cfspopcon.CompositeAlgorithm.from_list(
+        [
+            "set_radas_dir",
+            "read_atomic_data",
+            "build_CzLINT_for_seed_impurities",
+            "build_mean_charge_for_seed_impurities",
+            "run_forward_extended_lengyel_model",
+        ]
+    )
+    forward = forward_algorithm.update_dataset(
+        xr.Dataset(
+            data_vars=dict(
+                average_ion_mass=2.0 * ureg.amu, impurity_fraction=inverse["impurity_fraction"], **shared_inputs
+            )
+        )
+    )
+
+    assert forward["converged"].item()
+    assert np.isclose(
+        magnitude_in_units(forward["target_electron_temp"], ureg.eV),
+        magnitude_in_units(target_electron_temp, ureg.eV),
+        rtol=1e-2,
+    )
+    for key in ("alpha_t", "q_parallel", "separatrix_z_effective"):
+        assert np.isclose(
+            magnitude_in_units(forward[key], OUTPUT_UNITS[key]), magnitude_in_units(inverse[key], OUTPUT_UNITS[key]), rtol=1e-3
+        ), key
+
+
+def test_forward_model_is_registered_as_an_algorithm():
+    """Both models are usable from a CompositeAlgorithm, like the other models in this package."""
+    import cfspopcon
+
+    setup = [
+        "calc_magnetic_field_and_safety_factor",
+        "set_radas_dir",
+        "read_atomic_data",
+        "build_CzLINT_for_seed_impurities",
+        "build_mean_charge_for_seed_impurities",
+    ]
+
+    forward = cfspopcon.CompositeAlgorithm.from_list([*setup, "run_forward_extended_lengyel_model"])
+    assert "impurity_fraction" in forward.input_keys
+    assert "target_electron_temp" in forward.return_keys
+    assert "converged" in forward.return_keys
+
+    inverse = cfspopcon.CompositeAlgorithm.from_list([*setup, "run_inverse_extended_lengyel_model"])
+    assert "target_electron_temp" in inverse.input_keys
+    assert "impurity_fraction" in inverse.return_keys
+    assert "converged" in inverse.return_keys

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,10 +1,28 @@
-def test_readme():
-    """Test the Python text from the README file."""
+import pytest
+
+
+def readme_code_blocks():
+    """Return the contents of every ```python block in the README."""
     from pathlib import Path
 
     readme_text = (Path(__file__).parents[1]/"README.md").read_text().splitlines()
 
-    start_line = readme_text.index("```python")
-    stop_line = readme_text[start_line:].index("```")
+    blocks, block = [], None
+    for line in readme_text:
+        if block is None:
+            if line.strip() == "```python":
+                block = []
+        elif line.strip() == "```":
+            blocks.append("\n".join(block))
+            block = None
+        else:
+            block.append(line)
 
-    exec("\n".join(readme_text[start_line+1:start_line+stop_line]))
+    assert blocks, "No ```python blocks found in the README."
+    return blocks
+
+
+@pytest.mark.parametrize("block_number", range(len(readme_code_blocks())))
+def test_readme(block_number):
+    """Test the Python text from the README file."""
+    exec(readme_code_blocks()[block_number])


### PR DESCRIPTION
Adds a **forward solve** of the extended Lengyel model: given an impurity concentration, iterate to find the resulting target electron temperature. This is the opposite direction to the inverse solve already published here as `run_extended_lengyel_model_with_S_Zeff_and_alphat_correction`.

The implementation is ported from the `extended-lengyel-validation` project, which remains the authoritative regression suite for it.

## Using the new functionality

The new `extended_lengyel.iterative_solver` subpackage registers two algorithms, which share a single iteration loop:

| algorithm | you give it | it returns |
|---|---|---|
| `run_forward_extended_lengyel_model` | `impurity_fraction` | `target_electron_temp` |
| `run_inverse_extended_lengyel_model` | `target_electron_temp` | `impurity_fraction` |

Both also return `parallel_ion_flux_to_target`, `neutral_pressure_in_divertor`, `alpha_t`, `q_parallel`, `heat_flux_perp_to_target`, `separatrix_z_effective` and a `converged` flag.

Unlike the modular inverse model, these compute their own magnetic geometry and parallel heat flux internally, so the algorithm list is shorter — no `calc_magnetic_field_and_safety_factor`, `calc_fieldline_pitch_at_omp`, `calc_kappa_e0` or the `*_from_cc_fit` steps:

```python
import cfspopcon
import extended_lengyel
import xarray as xr
from cfspopcon.unit_handling import Quantity, ureg

algorithm = cfspopcon.CompositeAlgorithm.from_list([
    "set_radas_dir",
    "read_atomic_data",
    "build_CzLINT_for_seed_impurities",
    "build_mean_charge_for_seed_impurities",
    "run_forward_extended_lengyel_model",
])

seed_impurity_species, seed_impurity_weights = extended_lengyel.config.setup_impurities(["Nitrogen", "Argon"], [1.0, 0.05])

ds = xr.Dataset(data_vars=dict(
    seed_impurity_weights                       = seed_impurity_weights,
    seed_impurity_species                       = seed_impurity_species,
    # The impurity concentration is now an input, instead of the target electron temperature.
    impurity_fraction                           = Quantity(3.8, ureg.percent),
    separatrix_electron_density                 = Quantity(3.3e19, ureg.m**-3),
    power_crossing_separatrix                   = Quantity(5.5, ureg.MW),
    fraction_of_P_SOL_to_divertor               = 2/3,
    divertor_broadening_factor                  = 3.0,
    plasma_current                              = Quantity(1.0, ureg.MA),
    magnetic_field_on_axis                      = Quantity(2.5, ureg.T),
    major_radius                                = Quantity(1.65, ureg.m),
    minor_radius                                = Quantity(0.5, ureg.m),
    parallel_connection_length                  = Quantity(20, ureg.m),
    divertor_parallel_length                    = Quantity(5.0, ureg.m),
    elongation_psi95                            = 1.6,
    triangularity_psi95                         = 0.3,
    target_angle_of_incidence                   = Quantity(3.0, ureg.degree),
))

algorithm.validate_inputs(ds)
ds = algorithm.update_dataset(ds)

if ds["converged"].item():
    print(f"Target electron temperature: {ds['target_electron_temp'].item():.2f}")
else:
    print("The forward solve did not converge: its outputs are NaN.")
```

To run it in the inverse direction, swap the algorithm name for `run_inverse_extended_lengyel_model` and supply `target_electron_temp` instead of `impurity_fraction`.

The models can also be called directly, outside a `CompositeAlgorithm` — see `tests/test_forward_lengyel_model.py`.

### Two things to know before using it

**Always check `converged`.** The forward fixed-point iteration does not always converge — high impurity concentrations in particular diverge — and **a non-converged solve returns `NaN` for every physics output**. A converged-but-unphysical fixed point (a negative target temperature, or a negative impurity concentration in the inverse direction) is also reported as non-converged. So mask on the flag rather than assuming a number came back.

**This adds a second inverse solve.** `run_inverse_extended_lengyel_model` and the existing `run_extended_lengyel_model_with_S_Zeff_and_alphat_correction` are independent implementations of the same physics. They agree closely but not exactly, so pick one and stay with it rather than mixing them in one analysis. The README and the module docstrings say this too.

## Scope

The port was deliberately trimmed to the published NF 2025 model:

- **Included:** the forward and inverse solves without the divertor-pressure constraint.
- **Excluded:** the `_pdiv` variants (separatrix density constrained by divertor neutral pressure), and the unpublished Body 2026 extensions in the validation repo (pressure broadening `b_p`, divertor enrichment `f_enrich`, region-specific `kappa_e`, and the Moulton 2021 `t_B` flux-expansion term).
- **Naming:** `divertor_broadening_factor` is kept, matching the rest of this repository, rather than the validation repo's newer `heat_flux_broadening_factor`. No existing config files break.
- Also excluded: the Henderson NME 2021 / NF 2023 experimental datasets and the comparison notebook that ship with the validation project.

Because of the exclusions, this forward model differs from the validation repo's *current* forward model by up to ~2.3% (that is the region-specific `kappa_e` refinement, for which the validation golden was regenerated). The two `solver.py` files have therefore diverged, and future syncs will be manual merges rather than copies.

## Verification

| check | result |
|---|---|
| Reference values from the validation golden (forward) | 6 converged + 4 non-converged cases, `rtol=1e-5` |
| Reference values from the validation golden (inverse) | 12 cases, `rtol=1e-5` |
| Cross-check against the existing modular inverse model | agrees to 0.15% in `target_electron_temp`, and to better than 0.1% in `alpha_t`, `q_parallel` and `separatrix_z_effective` |
| Full test suite | 41 passed (27 before this PR) |
| `ruff check extended_lengyel` | clean |
| `iterative_solver` coverage | 98–100%; the uncovered lines are the physicality gate and a defensive zero-radiation guard |

The golden reference values were produced by the *original, pre-refactor* implementations of these models, so they are an anchor independent of the code being ported. They use the Mavrin polynomial atomic data, so the new tests do not require a radas dataset to be built.

The cross-check against the modular inverse model is the most meaningful check here: it ties the new subpackage to code that was already in this repository, independently of the private validation project.

## Other changes

- `extended_units.yaml` gains two keys, `iterations` and `converged`.
- `iterative_solver` is imported from `extended_lengyel/__init__.py`, so its algorithms register like every other subpackage here and the new unit keys are covered by `check_extended_units_dictionary()`.
- `tests/test_readme.py` now executes **every** ```python block in the README, not only the first, so the new forward-solve example is actually tested.

Note for anyone working across both repositories: `extended_lengyel.iterative_solver` and the standalone `extended_lengyel_validation` package register the same two algorithm names, and cfspopcon raises on duplicate registration — so the two cannot be imported in the same Python session.
